### PR TITLE
Update devcontainer configuration

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,9 @@
+# Devcontainer Configuration
+
+This folder contains configuration files required for Codespaces/devcontainers.
+Please do not modify its contents unless you know what you are doing and there
+is a specific change to the devcontainer configuration you need to make.
+
+If you believe you have a broken configuration or are unsure if you have the
+latest version of the configuration, please follow the 
+[instructions to add codespaces to your project](https://docs.opensafely.org/getting-started/how-to/add-github-codespaces-to-your-project/).

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,39 +1,56 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-    "name": "Python 3",
-    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-    // 2023-06-29: Use bullseye image instead of bookworm.
-    // At time of writing, bookworm is new and may have issues with dev containers:
-    // https://github.com/devcontainers/features/issues/576
-    "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+    "name": "OpenSAFELY",
+    "image": "ghcr.io/opensafely-core/research-template:v0",
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {
-            "moby": true,
-            "azureDnsAutoDetection": true,
-            "installDockerBuildx": true,
-            "version": "latest",
-            "dockerDashComposeVersion": "v2"
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
+    "postCreateCommand": "/bin/bash /opt/devcontainer/postCreate.sh ${containerWorkspaceFolder}",
+    "postAttachCommand": "/bin/bash /opt/devcontainer/postAttach.sh",
+    "forwardPorts": [
+        8787
+    ],
+    "portsAttributes": {
+        "8787": {
+            "label": "RStudio IDE"
         }
     },
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // "forwardPorts": [],
-    // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "pip3 install --user -r .devcontainer/requirements.in",
     // Configure tool-specific properties.
     "customizations": {
+        "codespaces": {
+            "repositories": {
+                "opensafely/server-instructions": {
+                    "permissions": {
+                        "contents": "read"
+                    }
+                }
+            }
+        },
         "vscode": {
             "extensions": [
                 "ms-python.python",
                 "ms-toolsai.jupyter",
-                "ms-toolsai.jupyter-renderers"
-            ]
+                "ms-toolsai.jupyter-renderers",
+                "bennettoxford.opensafely"
+            ],
+            "settings": {
+                "extensions.ignoreRecommendations": true,
+                "files.autoSave": "afterDelay",
+                "files.autoSaveDelay": 1000,
+                "git.autofetch": true,
+                "python.analysis.extraPaths": [".devcontainer/ehrql-main/"],
+                "python.defaultInterpreterPath": "/opt/venv/bin/python",
+                "python.terminal.activateEnvInCurrentTerminal": true,
+                "python.terminal.activateEnvironment": true,
+                "window.autoDetectColorScheme": true
+            }
         }
     },
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"
     "remoteEnv": {
-        "MAX_WORKERS": 2
+        "MAX_WORKERS": "2"
     }
 }

--- a/.devcontainer/requirements.in
+++ b/.devcontainer/requirements.in
@@ -1,2 +1,0 @@
-opensafely
-https://github.com/opensafely-core/ehrql/archive/main.zip


### PR DESCRIPTION
This updates the devcontainer configuration to [opensafely/research-template](https://github.com/opensafely/research-template) `fc4b32d`. Merging it should resolve opensafely-core/research-template-docker#95.